### PR TITLE
feat!: atualiza configuração do multer (upload) para suportar subpastas

### DIFF
--- a/src/config/multer.config.ts
+++ b/src/config/multer.config.ts
@@ -1,8 +1,9 @@
+
 import { HttpCode } from './../enums/HttpCode.enum';
 import multer from "multer";
 import path from "path";
 import fs, { existsSync } from "fs";
-import { unlink } from 'fs/promises'; // Importe 'unlink' do 'fs/promises'
+import { unlink } from 'fs/promises';
 import { ApiError } from "../errors/ApiError.error";
 
 export const uploadDir = path.join(__dirname, "../../public");
@@ -11,11 +12,17 @@ if (!fs.existsSync(uploadDir)) {
     fs.mkdirSync(uploadDir, { recursive: true });
 }
 
-const storage = multer.diskStorage({
-    destination: (_req, _file, cb) => cb(null, uploadDir),
-    filename: (_req, file, cb) =>
-        cb(null, Date.now() + "-" + file.originalname),
-});
+export function getMulterStorage(subfolder: string) {
+    const targetDir = path.join(uploadDir, subfolder);
+    if (!fs.existsSync(targetDir)) {
+        fs.mkdirSync(targetDir, { recursive: true });
+    }
+    return multer.diskStorage({
+        destination: (_req, _file, cb) => cb(null, targetDir),
+        filename: (_req, file, cb) =>
+            cb(null, Date.now() + "-" + file.originalname),
+    });
+}
 
 const fileFilter: multer.Options["fileFilter"] = (_req, file, cb) => {
     if (file.mimetype.startsWith("image/")) {
@@ -30,16 +37,23 @@ const limits = {
     fileSize: 1024 * 1024 * 5,
 };
 
-export const uploadImages = multer({
+export const uploadDenunciaImages = multer({
+    storage: getMulterStorage("denuncias"),
     fileFilter,
     limits,
-    storage
 });
 
-export const deleteImage =  async(imagesName: string[]):Promise<void>=>{
+export const uploadRegistroImages = multer({
+    storage: getMulterStorage("registros"),
+    fileFilter,
+    limits,
+});
+
+export const deleteImage =  async(imagesName: string[], subfolder: string = ""):Promise<void>=>{
+    const baseDir = subfolder ? path.join(uploadDir, subfolder) : uploadDir;
     if(imagesName.length > 0){
         for (let img of imagesName) {
-            const filePath = path.join(uploadDir, img);
+            const filePath = path.join(baseDir, img);
             if(!existsSync(filePath)){
                 throw new ApiError(`Não existe o arquivo ${img}`,HttpCode.BadRequest)
             }

--- a/src/routes/denuncia.routes.ts
+++ b/src/routes/denuncia.routes.ts
@@ -10,7 +10,6 @@ import {
   exportExcel,
 } from "../controllers/denuncia.controller"
 import { validateToken } from "../middlewares/auth.middleware"
-import { uploadImages } from "../config/multer.config"
 
 const router = express.Router()
 
@@ -19,10 +18,10 @@ router.get("/categorias", getByCategoria)
 router.get("/my", validateToken, getUserComplaint)
 router.get("/export", exportExcel);
 router.get("/:id", getById)
-router.post("/", validateToken ,uploadImages.array("imagens", 10), postDenuncia)
+router.post("/", validateToken, postDenuncia)
 router.get("/usuario", getUserComplaint)
 router.post("/", validateToken, postDenuncia)
-router.put("/:id", validateToken, uploadImages.array("imagens", 10), putDenuncia)
+router.put("/:id", validateToken, putDenuncia)
 router.delete("/:id", validateToken, deleteDenuncia)
 
 export default router

--- a/src/routes/upload.routes.ts
+++ b/src/routes/upload.routes.ts
@@ -1,11 +1,11 @@
-import express, {Request, Response } from "express";
+import express from "express";
 import { validateToken } from "../middlewares/auth.middleware";
 import { deleteFiles, uploadFiles } from "../controllers/upload.controller";
-import { uploadImages } from "../config/multer.config";
+import { uploadDenunciaImages } from "../config/multer.config";
 
 const router = express.Router()
 
-router.post('/', validateToken, uploadImages.array('imagens', 10), uploadFiles);
+router.post('/', validateToken, uploadDenunciaImages.array('imagens', 10), uploadFiles);
 
 router.post('/delete', validateToken, deleteFiles)
 


### PR DESCRIPTION
# Novas configurações do Multer

Como inicialmente a ideia era ter apenas upload de arquivos relacionados a denúncia, o multer era limitado a apenas realizar upload na pasta fixa em public/

Agora, com a necessidade de separação e de melhor organização, adicionei uma forma de tornar dinâmico a pasta de destino, como abaixo:

```typescript
export function getMulterStorage(subfolder: string) { //Passamos o nome do subdiretorio
    const targetDir = path.join(uploadDir, subfolder);
    if (!fs.existsSync(targetDir)) {
        fs.mkdirSync(targetDir, { recursive: true });
    }
    return multer.diskStorage({
        destination: (_req, _file, cb) => cb(null, targetDir),
        filename: (_req, file, cb) =>
            cb(null, Date.now() + "-" + file.originalname),
    });
}

export const uploadDenunciaImages = multer({
    storage: getMulterStorage("denuncias"),
    fileFilter,
    limits,
});
```

Agora, imagens das denúncias ficam armazenadas em public/denuncias, portanto, ao middleware passamos uploadDenunciaImages que já passa denuncias como subfolder

<img width="386" height="173" alt="image" src="https://github.com/user-attachments/assets/cdcecd59-67b8-46d6-9fdc-c65df9c08070" />

